### PR TITLE
Accurate TH-D72 modes.

### DIFF
--- a/tables/mode.md
+++ b/tables/mode.md
@@ -2,7 +2,4 @@
 |---|---|
 |*Code*|*Function*|
 |0|FM
-|1|AM
-|2|NFM
-
-# needs opdate
+|1|NFM


### PR DESCRIPTION
The TH-D72 doesn't have an AM mode, and Mode 1 is NFM.